### PR TITLE
Update SpatialSearchPanel.js

### DIFF
--- a/heron/lib/widgets/search/SpatialSearchPanel.js
+++ b/heron/lib/widgets/search/SpatialSearchPanel.js
@@ -522,6 +522,9 @@ Heron.widgets.search.SpatialSearchPanel = Ext.extend(Ext.Panel, {
 
         if (wfsOptions.protocol == 'fromWMSLayer') {
             // WMS has related WFS layer (usually GeoServer)
+            
+            //respect geometryName setting in the WFS parameters of the layer
+            var geometryName = targetLayer.metadata.wfs.geometryName ? targetLayer.metadata.wfs.geometryName :  'the_geom';   
             this.protocol = OpenLayers.Protocol.WFS.fromWMSLayer(targetLayer, {outputFormat: 'GML2'});
 
             // In rare cases may we have a WMS with multiple URLs n Array (for loadbalancing)


### PR DESCRIPTION
The spatialsearchpanel did not respect the setting of a geometryName in the WFS options of the layer, resulting in an empty <ogc:PropertyName> element in the WFS query. This pull request is a fix for that.

This fix was kindly funded by LBP|SIGHT.